### PR TITLE
Switching logic patch - on first block scenario

### DIFF
--- a/powerpool/jobmanagers/switching_jobmanager.py
+++ b/powerpool/jobmanagers/switching_jobmanager.py
@@ -194,6 +194,10 @@ class MonitorNetworkMulti(Jobmanager):
         return True
 
     def new_job_notif(self, event):
+        if not hasattr('job', event):
+            self.logger.info("No blocks mined yet, skipping switch logic")
+            return 
+        
         currency = event.job.currency
         flush = event.job.type == 0
         if currency == self.current_network:


### PR DESCRIPTION
- remove error `object event has not attribute` job
- replace error with a log INFO entry, specifying that there are no blocked that were currently mined